### PR TITLE
Bump Reaktive version to 1.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <rxjava.version>1.3.8</rxjava.version>
         <rxjava2.version>2.2.14</rxjava2.version>
         <rxjava3.version>3.0.0-RC7</rxjava3.version>
-        <reaktive.version>1.1.7</reaktive.version>
+        <reaktive.version>1.1.8</reaktive.version>
         <kotlin.version>1.3.61</kotlin.version>
         <kotlinx-coroutines.version>1.3.2</kotlinx-coroutines.version>
         <retrofit.version>2.6.2</retrofit.version>


### PR DESCRIPTION
Reaktive 1.1.7 has broken Bintray publication, needs update to 1.1.8